### PR TITLE
Add browserify tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "cwise": "^1.0.0"
+    "cwise": "^1.0.10"
   },
   "devDependencies": {
     "browserify": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "cwise": "^1.0.0"
   },
   "devDependencies": {
-    "zeros": "~0.0.0",
-    "tape": "^2.12.3"
+    "browserify": "^14.1.0",
+    "tape": "^2.12.3",
+    "zeros": "~0.0.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -1,0 +1,39 @@
+"use strict"
+
+var browserify = require("browserify")
+var tape = require("tape")
+var vm = require("vm")
+
+var cases = [ "test" ]
+
+bundleCasesFrom(0)
+
+function bundleCasesFrom(i) {
+  if (i>=cases.length) return
+  var b = browserify()
+  b.ignore("tape")
+  b.add(__dirname + "/" + cases[i] + ".js")
+  tape(cases[i], function(t) { // Without nested tests, the asynchronous nature of bundle causes issues with tape...
+    b.bundle(function(err, src) {
+      if(err) {
+        throw new Error("failed to bundle!")
+      }
+      vm.runInNewContext(src, {
+        test: t.test.bind(t),
+        Buffer: Buffer,
+        Int8Array: Int8Array,
+        Int16Array: Int16Array,
+        Int32Array: Int32Array,
+        Float32Array: Float32Array,
+        Float64Array: Float64Array,
+        Uint8Array: Uint8Array,
+        Uint16Array: Uint16Array,
+        Uint32Array: Uint32Array,
+        Uint8ClampedArray: Uint8ClampedArray,
+        console: { log: console.log.bind(console) }
+      })
+      t.end()
+    })
+  })
+  bundleCasesFrom(i+1)
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,11 @@
-"use strict"
-
 var zeros = require("zeros")
 var fill = require("../index.js")
 
-require("tape")(function(t) {
+if(typeof test === "undefined") {
+  test = require("tape")
+}
+
+test('fill zeros', function(t) {
 
   var x = zeros([10,10])
   


### PR DESCRIPTION
Copied from https://github.com/scijs/cwise/blob/master/test/browserify.js

... which helped me get to the root of a `cwise` + `uglify-js@2.8.x` bug first reported in https://github.com/plotly/plotly.js/pull/1450#issuecomment-284803443